### PR TITLE
feat(config): 添加首次使用配置引导和错误定义

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 .DS_Store
+
+cmd

--- a/config/init.go
+++ b/config/init.go
@@ -1,8 +1,12 @@
 package config
 
 import (
+	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
+
+	customErrors "github.com/TIC-DLUT/nano-claude-code/errors"
 
 	"github.com/spf13/viper"
 )
@@ -17,7 +21,82 @@ func LoadConfig() error {
 
 	err := viper.ReadInConfig()
 
-	// TODO: 文件不存在，启动创建的引导
+	if err != nil {
+		var configFileNotExit viper.ConfigFileNotFoundError
+		// 配置文件未找到，引导新建
+		if errors.As(err, &configFileNotExit) {
+			if err := newConfigFile(filepath.Join(homePath, ".nano-claude-code")); err != nil {
+				return err
+			} else {
+				// 配置文件新建成功，重新读取配置
+				return viper.ReadInConfig()
+			}
+		}
+		return customErrors.ReadInConfigError
+	}
+	return nil
+}
 
-	return err
+func newConfigFile(configDir string) error {
+	fmt.Println("Welcome to nano-claude-code!")
+	fmt.Println("First time use requires configuring LLM parameters")
+	fmt.Println()
+
+	// 获取 BaseURL
+	fmt.Print("Please enter API Base URL (press Enter for official API): ")
+	var baseURL string
+	fmt.Scanf("%s", &baseURL)
+	if baseURL == "" {
+		baseURL = "https://api.anthropic.com"
+		fmt.Println("Using default address: https://api.anthropic.com")
+	}
+
+	// 获取 API Key
+	var apiKey string
+	for {
+		fmt.Print("Please enter API Key: ")
+		fmt.Scanf("%s", &apiKey)
+		if apiKey == "" {
+			fmt.Println("API Key cannot be empty, please try again")
+		} else {
+			break
+		}
+	}
+
+	// 获取 Model
+	var model string
+	for {
+		fmt.Print("Please enter model ID: ")
+		fmt.Scanf("%s", &model)
+		if model == "" {
+			fmt.Println("Model ID cannot be empty, please try again")
+		} else {
+			break
+		}
+	}
+
+	//构建文本内容
+	configContent := fmt.Sprintf(`{
+    "llm": {
+        "baseurl": "%s",
+        "apikey": "%s",
+        "model": "%s"
+    }
+}`, baseURL, apiKey, model)
+
+	// 创建配置目录
+	if err := os.MkdirAll(configDir, 0755); err != nil {
+		return customErrors.ConfigDirCreateError
+	}
+
+	// 写入配置文件
+	configPath := filepath.Join(configDir, "config.json")
+
+	if err := os.WriteFile(configPath, []byte(configContent), 0644); err != nil {
+		return customErrors.ConfigFileWriteError
+	}
+
+	fmt.Println()
+	fmt.Println("Configuration file saved to:", configPath)
+	return nil
 }

--- a/config/init.go
+++ b/config/init.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
 	"os"
@@ -76,13 +77,27 @@ func newConfigFile(configDir string) error {
 	}
 
 	//构建文本内容
-	configContent := fmt.Sprintf(`{
-    "llm": {
-        "baseurl": "%s",
-        "apikey": "%s",
-        "model": "%s"
-    }
-}`, baseURL, apiKey, model)
+	type Config struct {
+		LLM struct {
+			BaseURL string `json:"baseurl"`
+			APIKey  string `json:"apikey"`
+			Model   string `json:"model"`
+		} `json:"llm"`
+	}
+	configContent, err := json.MarshalIndent(Config{
+		LLM: struct {
+			BaseURL string `json:"baseurl"`
+			APIKey  string `json:"apikey"`
+			Model   string `json:"model"`
+		}{
+			BaseURL: baseURL,
+			APIKey:  apiKey,
+			Model:   model,
+		},
+	}, "", "  ")
+	if err != nil {
+		return customErrors.ConfigFileWriteError
+	}
 
 	// 创建配置目录
 	if err := os.MkdirAll(configDir, 0755); err != nil {

--- a/config/init_test.go
+++ b/config/init_test.go
@@ -1,0 +1,14 @@
+package config
+
+import (
+	"testing"
+
+	"github.com/spf13/viper"
+)
+
+func TestInitConfig(t *testing.T) {
+	if err := LoadConfig(); err != nil {
+		t.Error(err)
+	}
+	t.Logf("Config loaded successfully%s,%s,%s", viper.GetString("llm.baseurl"), viper.GetString("llm.apikey"), viper.GetString("llm.model"))
+}

--- a/errors/config.go
+++ b/errors/config.go
@@ -1,0 +1,9 @@
+package errors
+
+import "errors"
+
+var (
+	ReadInConfigError    = errors.New("failed to get config from the config file")
+	ConfigFileWriteError = errors.New("failed to write config file")
+	ConfigDirCreateError = errors.New("failed to create config directory")
+)


### PR DESCRIPTION
添加首次使用配置引导和错误定义，具体测试如下 @dingdinglz @pykelysia 
首次使用会引导完成配置文件
<img width="1852" height="644" alt="image" src="https://github.com/user-attachments/assets/8b8a9f76-f605-483e-9798-8f966b88e0c1" />
如果有配置文件不会引导，直接使用
<img width="1808" height="276" alt="image" src="https://github.com/user-attachments/assets/0c482f13-9bb9-4b35-8990-7d7665410dc5" />
可以正确读取配置文件
<img width="1804" height="848" alt="image" src="https://github.com/user-attachments/assets/fa57a052-4e9f-4144-b1ed-f0cc4f42168c" />